### PR TITLE
[#15] Detect non-quoted .rsp file references

### DIFF
--- a/src/project/compileCommands.ts
+++ b/src/project/compileCommands.ts
@@ -6,7 +6,7 @@ import { JSON_SPACING } from '../consts';
 import * as console from "../console";
 
 
-export const RE_RESPONSE_FILE_PATH = `(?<=@\\"|@').*.rsp`
+export const RE_RESPONSE_FILE_PATH = `(?<=@\\"|@'|@).*.rsp`;
 
 export class CompileCommands {
 


### PR DESCRIPTION
Closes https://github.com/boocs/ue4-intellisense-fixes/issues/15

Supports non-quoted rsp file references while parsing the compileCommand files. A simple one-line update to the regex used to parse the commands