### PR TITLE
[#17] Fixes the regex used to detect UE editor generated files

### DIFF
--- a/src/extension/fixes/generated.ts
+++ b/src/extension/fixes/generated.ts
@@ -14,7 +14,7 @@ import * as console from "../../console";
 const GLOB_UE_EDITOR_GENERATED = "Intermediate/Build/**/UnrealEditor/Inc/**/*.generated.h"
 const GLOB_UE4_EDITOR_GENERATED = "Intermediate/Build/**/UE4Editor/Inc/**/*.generated.h"
 
-const REGEX_UE_EDITOR_GENERATED = /(?<!Engine)[\/|\\]Intermediate[\/|\\]Build[\/|\\]\w+[\/|\\](?:Unreal|UE4)Editor[\/|\\]Inc/gm
+const REGEX_UE_EDITOR_GENERATED = /(?<!Engine)[\/\\]Intermediate[\/\\]Build[\/\\](?:\w+[\/\\]){1,2}(?:Unreal|UE4)Editor[\/\\]Inc/gm
 
 
 export async function fixGenerated(project: ProjectUE4) : Promise<void> {


### PR DESCRIPTION
Closes https://github.com/boocs/ue4-intellisense-fixes/issues/17

Fixes and refactors the regex used to detect the editor files
- Allows the regex to match up to 2 folders between the `Build` and
  the `UnrealEditor` folders. Previously it only supported 1
- Removes the `|` in the regex, this would have supported formats
  like `Build|Mac|UnrealEditor` which is likely unintentional